### PR TITLE
Add container capabilities supports to container

### DIFF
--- a/kubernetes/K8sContainer.py
+++ b/kubernetes/K8sContainer.py
@@ -13,9 +13,10 @@ import yaml
 from kubernetes.K8sVolumeMount import K8sVolumeMount
 from kubernetes.models.v1.Container import Container
 from kubernetes.models.v1.ContainerPort import ContainerPort
+from kubernetes.models.v1.EnvVar import EnvVar
 from kubernetes.models.v1.Probe import Probe
 from kubernetes.models.v1.ResourceRequirements import ResourceRequirements
-from kubernetes.models.v1.EnvVar import EnvVar
+from kubernetes.models.v1.SecurityContext import SecurityContext
 
 
 class K8sContainer(object):
@@ -93,6 +94,26 @@ class K8sContainer(object):
             raise SyntaxError('K8sContainer: could not add readiness_probe: [ {} ]'.format(kwargs))
         probe = Probe(kwargs)
         self.readiness_probe = probe
+
+    def add_capabilities(self, caps):
+        if not isinstance(caps, list):
+            raise SyntaxError('K8sContainer: could not add capabilities: [ {} ]'.format(caps))
+        context = self.model.security_context or SecurityContext()
+        if context.capabilities is None:
+            context.capabilities = dict(add=list())
+        context.capabilities['add'].extend(caps)
+        self.model.security_context = context
+
+    # ------------------------------------------------------------------------------------- drop
+
+    def drop_capabilities(self, caps):
+        if not isinstance(caps, list):
+            raise SyntaxError('K8sContainer: could not drop capabilities: [ {} ]'.format(caps))
+        context = self.model.security_context or SecurityContext()
+        if context.capabilities is None:
+            context.capabilities = dict(drop=list())
+        context.capabilities['drop'].extend(caps)
+        self.model.security_context = context
 
     # -------------------------------------------------------------------------------------  args
 

--- a/kubernetes/models/v1/SecurityContext.py
+++ b/kubernetes/models/v1/SecurityContext.py
@@ -25,6 +25,7 @@ class SecurityContext(object):
         self.run_as_user = None
         self.run_as_non_root = False
         self.read_only_root_file_system = False
+        self.capabilities = None
 
         if model is not None:
             m = filter_model(model)
@@ -35,7 +36,7 @@ class SecurityContext(object):
 
     # ------------------------------------------------------------------------------------- serialize
 
-    def json(self):
+    def serialize(self):
         data = {}
         if self.privileged is not None:
             data['privileged'] = self.privileged
@@ -45,4 +46,6 @@ class SecurityContext(object):
             data['runAsNonRoot'] = self.run_as_non_root
         if self.read_only_root_file_system is not None:
             data['readOnlyRootFilesystem'] = self.read_only_root_file_system
+        if self.capabilities is not None:
+            data['capabilities'] = self.capabilities
         return data

--- a/tests/test_k8s_container.py
+++ b/tests/test_k8s_container.py
@@ -101,6 +101,45 @@ class K8sContainerTest(BaseTest):
         self.assertEqual(1, len(c.volume_mounts))
         self.assertIn(mount.model, c.volume_mounts)
 
+    # ------------------------------------------------------------------------------------- add capabilities
+
+    def test_add_capabilities_invalid_args(self):
+        name = "yomama"
+        image = "redis"
+        with self.assertRaises(SyntaxError):
+            c = K8sContainer(name=name, image=image)
+            c.add_capabilities('NET_RAW')
+
+    def test_add_capabilities(self):
+        name = "yomama"
+        image = "redis"
+        c = K8sContainer(name=name, image=image)
+        c.add_capabilities(['NET_RAW'])
+        data = c.serialize()
+        self.assertIsInstance(data['securityContext']['capabilities'], dict)
+        self.assertIsInstance(data['securityContext']['capabilities']['add'], list)
+        self.assertEqual(data['securityContext']['capabilities']['add'], ['NET_RAW'])
+
+
+    # ------------------------------------------------------------------------------------- drop capabilities
+
+    def test_drop_capabilities_invalid_args(self):
+        name = "yomama"
+        image = "redis"
+        with self.assertRaises(SyntaxError):
+            c = K8sContainer(name=name, image=image)
+            c.drop_capabilities('NET_RAW')
+
+    def test_drop_capabilities(self):
+        name = "yomama"
+        image = "redis"
+        c = K8sContainer(name=name, image=image)
+        c.drop_capabilities(['NET_RAW'])
+        data = c.serialize()
+        self.assertIsInstance(data['securityContext']['capabilities'], dict)
+        self.assertIsInstance(data['securityContext']['capabilities']['drop'], list)
+        self.assertEqual(data['securityContext']['capabilities']['drop'], ['NET_RAW'])
+
     # ------------------------------------------------------------------------------------- add liveness probe
 
     def test_add_liveness_probe(self):


### PR DESCRIPTION
This PR adds two functions "add_capabilities" and "drop_capabilities" to K8sContainer, which allows to specify linux capabilities via SecurityContext.