### PR TITLE
Filter labels without name

### DIFF
--- a/kubernetes/K8sPod.py
+++ b/kubernetes/K8sPod.py
@@ -408,27 +408,14 @@ class K8sPod(K8sObject):
 
     # ------------------------------------------------------------------------------------- filtering
 
-    @staticmethod
-    def get_by_name(config=None, name=None):
-        if config is None:
-            config = K8sConfig()
+    @classmethod
+    def get_by_name(cls, config=None, name=None):
         if not is_valid_string(name):
             raise SyntaxError(
                 'K8sPod.get_by_name(): name: [ {0} ] is invalid.'.format(name))
-
-        pod_list = []
-        data = {'labelSelector': 'name={0}'.format(name)}
-        pods = K8sPod(config=config, name=name).get_with_params(data=data)
-
-        for pod in pods:
-            try:
-                p = Pod(pod)
-                k8s_pod = K8sPod(config=config, name=p.metadata.name).get()
-                pod_list.append(k8s_pod)
-            except NotFoundException:
-                pass
-
-        return pod_list
+        return cls.get_by_labels(config=config, labels={
+            "name": name,
+        })
 
     @staticmethod
     def get_by_labels(config=None, labels=None):
@@ -441,7 +428,7 @@ class K8sPod(K8sObject):
         pod_list = []
         selector = ",".join(['%s=%s' % (key, value) for (key, value) in labels.items()])
         data = {'labelSelector': selector}
-        p = K8sPod(config=config, name=labels['name'])
+        p = K8sPod(config=config, name="")
         pods = p.get_with_params(data=data)
 
         for pod in pods:

--- a/tests/test_k8s_pod.py
+++ b/tests/test_k8s_pod.py
@@ -924,8 +924,9 @@ class K8sPodTest(BaseTest):
             self.assertIsInstance(pods, list)
             self.assertEqual(1, len(pods))
             self.assertEqual(pod, pods[0])
-        else:
-            self.fail('Could not connect to minikube')
+
+            pods = K8sPod.get_by_labels(config=pod.config, labels={'test.label': "world"})
+            self.assertEqual(0, len(pods))
 
     # ------------------------------------------------------------------------------------- api - create
 

--- a/tests/test_k8s_pod.py
+++ b/tests/test_k8s_pod.py
@@ -910,6 +910,23 @@ class K8sPodTest(BaseTest):
             self.assertEqual(1, len(pods))
             self.assertEqual(pod, pods[0])
 
+    def test_get_by_labels_without_name(self):
+        name = "yocontainer"
+        container = _utils.create_container(name=name)
+        name = "yopod-{0}".format(str(uuid.uuid4()))
+        pod = _utils.create_pod(name=name)
+        pod.add_container(container)
+        pod.add_label("test.label", "hello")
+
+        if _utils.is_reachable(pod.config):
+            pod.create()
+            pods = K8sPod.get_by_labels(config=pod.config, labels={'test.label': "hello"})
+            self.assertIsInstance(pods, list)
+            self.assertEqual(1, len(pods))
+            self.assertEqual(pod, pods[0])
+        else:
+            self.fail('Could not connect to minikube')
+
     # ------------------------------------------------------------------------------------- api - create
 
     def test_create_without_containers(self):


### PR DESCRIPTION
I've come across an issue trying to get a list of pods by label other than name. The query building logic expected the name to be present.

The primary change is essentially to replace labels["name"] for "", which works just fine on minikube as well as our own kubernetes cluster. Having to set the name argument even when it is not required is a general annoyance in the API. 

I've also reduced the get_by_name implementation to call get_by_labels instead, as the implementation is more general. Validation portion is left as-is.

As a general note, I have found running the unit tests harder than it would seem necessary. All tests pass if k8s is not running at all, random failures occur when running with minikube. Seems like tests that need connectivity should skip if k8s is unavailable, same for those that require specific features.