### PR TITLE
K8sPersistentVolumes: fixes create/mount of PVC for pod volumes.

### DIFF
--- a/kubernetes/K8sPersistentVolume.py
+++ b/kubernetes/K8sPersistentVolume.py
@@ -13,6 +13,7 @@ from kubernetes.K8sExceptions import TimedOutException
 from kubernetes.models.v1.PersistentVolume import PersistentVolume
 from kubernetes.models.v1.PersistentVolumeSpec import PersistentVolumeSpec
 from kubernetes.models.v1.Volume import Volume
+from kubernetes.utils import is_valid_string
 
 READY_WAIT_TIMEOUT_SECONDS = 60
 
@@ -211,3 +212,25 @@ class K8sPersistentVolume(K8sObject):
         if not hasattr(self.source, 'path'):
             raise NotImplementedError()
         self.source.path = p
+
+    # ------------------------------------------------------------------------------------- storage_class_name
+
+    @property
+    def storage_class_name(self):
+        return self.model.spec.storage_class_name
+
+    @storage_class_name.setter
+    def storage_class_name(self, name=None):
+        if not is_valid_string(name):
+            raise SyntaxError("K8sPersistentVolume: storage_class_name: [ {} ] is invalid.".format(name))
+        self.model.spec.storage_class_name = name
+
+    # ------------------------------------------------------------------------------------- reclaim_policy
+
+    @property
+    def reclaim_policy(self):
+        return self.model.spec.reclaim_policy
+
+    @reclaim_policy.setter
+    def reclaim_policy(self, pol=None):
+        self.model.spec.reclaim_policy = pol

--- a/kubernetes/K8sPersistentVolumeClaim.py
+++ b/kubernetes/K8sPersistentVolumeClaim.py
@@ -104,3 +104,13 @@ class K8sPersistentVolumeClaim(K8sObject):
 
         selector = LabelSelector(sel)
         self.model.spec.selector = selector
+
+    # ------------------------------------------------------------------------------------- storage_class_name
+
+    @property
+    def storage_class_name(self):
+        return self.model.spec.storage_class_name
+
+    @storage_class_name.setter
+    def storage_class_name(self, name=None):
+        self.model.spec.storage_class_name = name

--- a/kubernetes/models/v1/PersistentVolumeClaimSpec.py
+++ b/kubernetes/models/v1/PersistentVolumeClaimSpec.py
@@ -26,6 +26,7 @@ class PersistentVolumeClaimSpec(object):
         self._selector = LabelSelector()
         self._resources = ResourceRequirements()
         self._volume_name = None
+        self._storage_class_name = ""
 
         self.access_modes = ['ReadWriteOnce']
         self.resources.requests = {'storage': '10Gi'}
@@ -36,10 +37,12 @@ class PersistentVolumeClaimSpec(object):
     def _build_with_model(self, model=None):
         if 'accessModes' in model:
             self.access_modes = model['accessModes']
-        if 'selector' in model:
-            self.selector = LabelSelector(model['selector'])
         if 'resources' in model:
             self.resources = ResourceRequirements(model['resources'])
+        if 'storageClassName' in model:
+            self.storage_class_name = model['storageClassName']
+        if 'selector' in model:
+            self.selector = LabelSelector(model['selector'])
         if 'volumeName' in model:
             self.volume_name = model['volumeName']
 
@@ -56,6 +59,18 @@ class PersistentVolumeClaimSpec(object):
         filtered = list(filter(lambda x: x in PersistentVolumeSpec.VALID_ACCESS_MODES, modes))
         self._access_modes = filtered
 
+    # ------------------------------------------------------------------------------------- resources
+
+    @property
+    def resources(self):
+        return self._resources
+
+    @resources.setter
+    def resources(self, res=None):
+        if not isinstance(res, ResourceRequirements):
+            raise SyntaxError('PersistentVolumeClaimSpec: resources: [ {} ] is invalid.'.format(res))
+        self._resources = res
+
     # ------------------------------------------------------------------------------------- selector
 
     @property
@@ -68,17 +83,17 @@ class PersistentVolumeClaimSpec(object):
             raise SyntaxError('PersistentVolumeClaimSpec: selector: [ {} ] is invalid.'.format(sel))
         self._selector = sel
 
-    # ------------------------------------------------------------------------------------- resources
+    # ------------------------------------------------------------------------------------- storage_class_name
 
     @property
-    def resources(self):
-        return self._resources
+    def storage_class_name(self):
+        return self._storage_class_name
 
-    @resources.setter
-    def resources(self, res=None):
-        if not isinstance(res, ResourceRequirements):
-            raise SyntaxError('PersistentVolumeClaimSpec: resources: [ {} ] is invalid.'.format(res))
-        self._resources = res
+    @storage_class_name.setter
+    def storage_class_name(self, name=None):
+        if not is_valid_string(name):
+            raise SyntaxError('PersistentVolumeClaimSpec: storage_class_name: [ {} ] is invalid.'.format(name))
+        self._storage_class_name = name
 
     # ------------------------------------------------------------------------------------- volumeName
 
@@ -100,6 +115,8 @@ class PersistentVolumeClaimSpec(object):
             data['accessModes'] = self.access_modes
         if self.selector is not None:
             data['selector'] = self.selector.serialize()
+        if self.storage_class_name is not None:
+            data['storageClassName'] = self.storage_class_name
         if self.resources is not None:
             data['resources'] = self.resources.serialize()
         if self.volume_name is not None:

--- a/kubernetes/models/v1/PersistentVolumeSpec.py
+++ b/kubernetes/models/v1/PersistentVolumeSpec.py
@@ -70,6 +70,7 @@ class PersistentVolumeSpec(object):
         self._access_modes = ['ReadWriteOnce']
         self._claim_ref = None
         self._reclaim_policy = 'Retain'
+        self._storage_class_name = ""
 
         if model is not None:
             self._build_with_model(model)
@@ -97,6 +98,8 @@ class PersistentVolumeSpec(object):
             self.reclaim_policy = model['persistentVolumeReclaimPolicy']
         if 'persistentVolumeClaim' in model:
             self.persistentVolumeClaim = PersistentVolumeClaimVolumeSource(model['persistentVolumeClaim'])
+        if 'storageClassName' in model:
+            self._storage_class_name = model['storageClassName']
 
     # ------------------------------------------------------------------------------------- aws ebs
 
@@ -255,6 +258,18 @@ class PersistentVolumeSpec(object):
             raise SyntaxError('PersistentVolumeSpec: persistentVolumeClaim: [ {} ] is invalid.'.format(pvc))
         self._persistentVolumeClaim = pvc
 
+    # ------------------------------------------------------------------------------------- storageClassName
+
+    @property
+    def storage_class_name(self):
+        return self._storage_class_name
+
+    @storage_class_name.setter
+    def storage_class_name(self, name=None):
+        if not is_valid_string(name):
+            raise SyntaxError('PersistentVolumeSpec: storage_class_name: [ {} ] is invalid.'.format(name))
+        self._storage_class_name = name
+
     # ------------------------------------------------------------------------------------- serialize
 
     def serialize(self):
@@ -285,4 +300,6 @@ class PersistentVolumeSpec(object):
             data['persistentVolumeReclaimPolicy'] = self.reclaim_policy
         if self.persistentVolumeClaim is not None:
             data['persistentVolumeClaim'] = self.reclaim_policy
+        if self.storage_class_name is not None:
+            data['storageClassName'] = self.storage_class_name
         return data


### PR DESCRIPTION
Hey guys, hope you're doing well!

So the API for persistent volumes has changed a little bit. A Claim (PVC) must have the exact same attributes as its Volume (PV), except for its resource requests, most importantly storageClassName (which we didn't have before).

I've tested this on minikube 1.8 and a QA 1.8 K8s cluster on AWS. When you get a minute, can you please validate that this works for you as well? The PVC creates a random PV to satisfy its needs, at a random path, if the definitions don't line up.