### PR TITLE
Fix import statement for LoadBalancerStatus

### DIFF
--- a/kubernetes/models/v1/LoadBalancerStatus.py
+++ b/kubernetes/models/v1/LoadBalancerStatus.py
@@ -6,9 +6,7 @@
 # file 'LICENSE.md', which is part of this source code package.
 #
 
-from kubernetes.models.v1 import (
-    LoadBalancerIngress
-)
+from kubernetes.models.v1.LoadBalancerIngress import LoadBalancerIngress
 from kubernetes.utils import is_valid_list
 
 


### PR DESCRIPTION
Fixes `TypeError: 'module' object is not callable` when deploying a LoadBalancer service.