### PR TITLE
Fixed using the unsafe YAML loader by default

### DIFF
--- a/kubernetes_py/K8sConfig.py
+++ b/kubernetes_py/K8sConfig.py
@@ -173,7 +173,7 @@ class K8sConfig(object):
             raise IOError('K8sConfig: kubeconfig: [ {0} ] doesn\'t exist.'.format(filename))
         try:
             with open(filename, 'r') as stream:
-                dotconf = yaml.load(stream)
+                dotconf = yaml.safe_load(stream)
         except YAMLError as err:
             raise SyntaxError('K8sConfig: kubeconfig: [ {0} ] is not a valid YAML file: {1}'.format(filename, err))
 


### PR DESCRIPTION
This prevents exploits by using execution code in yaml.  Shouldn't
really need that in your k8s configs I'd imagine!  In any case, it also
prevents a warning from being issued every time it's used, which was
dramatically affecting the powerline-kubernetes plugin.