### PR TITLE
Fixed missing attribute initialization

### DIFF
--- a/kubernetes_py/K8sConfig.py
+++ b/kubernetes_py/K8sConfig.py
@@ -57,6 +57,7 @@ class K8sConfig(object):
         self.cert = None
         self.client_certificate = None
         self.client_key = None
+        self.cert_data = None
         self.pull_secret = None
         self.namespace = None
         self.token = None


### PR DESCRIPTION
Previously, using a configuration file with a user defined as
```
users:
- name: "my_user"
  user:
    token: "my_token"
```
would not allow proper connection and fetching pod data.